### PR TITLE
Implement admin menu API with JWT auth

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const cors = require('cors');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const adminMenuRoutes = require('./routes/adminMenu');
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const mongoUri = process.env.MONGO_URI || 'mongodb://localhost:27017/bmc';
+mongoose
+  .connect(mongoUri)
+  .then(() => console.log('MongoDB connected'))
+  .catch((err) => console.error('MongoDB connection error', err));
+
+app.use('/api/admin/menu', adminMenuRoutes);
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => console.log(`Server listening on ${PORT}`));

--- a/server/middleware/adminAuth.js
+++ b/server/middleware/adminAuth.js
@@ -1,0 +1,19 @@
+const jwt = require('jsonwebtoken');
+
+module.exports = function (req, res, next) {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ message: 'Authorization required' });
+  }
+  const token = authHeader.split(' ')[1];
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secret');
+    if (decoded.role !== 'admin' && !decoded.isAdmin) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+    req.user = decoded;
+    next();
+  } catch (err) {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+};

--- a/server/models/MenuItem.js
+++ b/server/models/MenuItem.js
@@ -1,0 +1,13 @@
+const mongoose = require('mongoose');
+
+const menuItemSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true },
+    price: { type: Number, required: true },
+    image: String,
+    active: { type: Boolean, default: true },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('MenuItem', menuItemSchema);

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node index.js"
   },
   "keywords": [],
   "author": "",

--- a/server/routes/adminMenu.js
+++ b/server/routes/adminMenu.js
@@ -1,0 +1,46 @@
+const express = require('express');
+const MenuItem = require('../models/MenuItem');
+const adminAuth = require('../middleware/adminAuth');
+
+const router = express.Router();
+
+// Add a new menu item
+router.post('/', adminAuth, async (req, res) => {
+  try {
+    const item = new MenuItem(req.body);
+    await item.save();
+    res.status(201).json(item);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+// Update existing menu item
+router.patch('/:id', adminAuth, async (req, res) => {
+  try {
+    const item = await MenuItem.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!item) return res.status(404).json({ message: 'Not found' });
+    res.json(item);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+// Deactivate or remove menu item
+router.delete('/:id', adminAuth, async (req, res) => {
+  try {
+    const { hard } = req.query;
+    let item;
+    if (hard === 'true') {
+      item = await MenuItem.findByIdAndDelete(req.params.id);
+    } else {
+      item = await MenuItem.findByIdAndUpdate(req.params.id, { active: false }, { new: true });
+    }
+    if (!item) return res.status(404).json({ message: 'Not found' });
+    res.json(item);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- create express server boilerplate
- add MenuItem mongoose model
- implement `/api/admin/menu` routes for POST, PATCH and DELETE
- secure menu routes with JWT-based admin authorization
- add start script

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6862817cf0148333939b9954984257a8