### PR TITLE
Implement minimal auth API server

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,64 @@
+import express, { Request, Response } from 'express';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import cors from 'cors';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+interface User {
+  id: number;
+  username: string;
+  passwordHash: string;
+}
+
+const users: User[] = [];
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.post('/api/signup', async (req: Request, res: Response) => {
+  const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ message: 'Username and password required' });
+  }
+
+  const existing = users.find((u) => u.username === username);
+  if (existing) {
+    return res.status(400).json({ message: 'User already exists' });
+  }
+
+  const passwordHash = await bcrypt.hash(password, 10);
+  const user: User = { id: users.length + 1, username, passwordHash };
+  users.push(user);
+
+  res.status(201).json({ message: 'User created' });
+});
+
+app.post('/api/login', async (req: Request, res: Response) => {
+  const { username, password } = req.body;
+  const user = users.find((u) => u.username === username);
+
+  if (!user) {
+    return res.status(401).json({ message: 'Invalid username or password' });
+  }
+
+  const passwordValid = await bcrypt.compare(password, user.passwordHash);
+  if (!passwordValid) {
+    return res.status(401).json({ message: 'Invalid username or password' });
+  }
+
+  const token = jwt.sign(
+    { userId: user.id, username: user.username },
+    process.env.JWT_SECRET || 'secret',
+    { expiresIn: '1h' }
+  );
+
+  res.json({ token });
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- implement a tiny Express server in TypeScript
- add `/api/signup` and `/api/login` routes using bcrypt and jsonwebtoken
- make the server listen on a configurable port

## Testing
- `npm test --silent` (fails: `Error: no test specified`)

------
https://chatgpt.com/codex/tasks/task_e_686281645ff083338e9127b7b7ab634c