### PR TITLE
Add dashboard API route

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -5,6 +5,7 @@ import dotenv from 'dotenv';
 import crypto from 'crypto';
 import cors from 'cors';
 import adminMenuRoutes from './routes/adminMenu';
+import dashboardRoutes from './routes/dashboard';
 
 dotenv.config();
 
@@ -12,6 +13,7 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 app.use('/api/admin/menu', adminMenuRoutes);
+app.use('/api/dashboard', dashboardRoutes);
 
 const mongoUri = process.env.MONGO_URI || 'mongodb://localhost:27017/buyme';
 mongoose

--- a/server/routes/dashboard.ts
+++ b/server/routes/dashboard.ts
@@ -1,0 +1,33 @@
+import express from 'express';
+
+const router = express.Router();
+
+// GET /api/dashboard
+router.get('/', (req, res) => {
+  // Mock dashboard data
+  const data = {
+    username: 'JohnDoe',
+    avatar: 'https://placehold.co/48x48',
+    earnings: 125.5,
+    transactions: [
+      {
+        id: '1',
+        name: 'Alice',
+        message: 'Great job!',
+        amount: 5,
+        timeAgo: '2 days ago',
+      },
+      {
+        id: '2',
+        name: 'Bob',
+        message: 'Keep it up!',
+        amount: 3,
+        timeAgo: '5 days ago',
+      },
+    ],
+  };
+
+  res.json(data);
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- create `server/routes/dashboard.ts` with mock data handler for `/api/dashboard`
- mount dashboard router in `server/index.ts`

## Testing
- `npm test` in `server` *(fails: no test specified)*
- `npm test` in `front-end` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863804afb3c8333ba955fb0815802f1