### PR TITLE
Configure API proxy rewrites

### DIFF
--- a/front-end/next.config.ts
+++ b/front-end/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async rewrites() {
+    return [
+      {
+        source: "/api/:path*",
+        destination: "http://localhost:3001/api/:path*",
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- forward `/api/*` requests from Next.js dev server to the backend

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm start` from `server` *(starts server)*

------
https://chatgpt.com/codex/tasks/task_e_6863918b40688333b834f8b68ebf4fe7