### PR TITLE
Add profile retrieval after login

### DIFF
--- a/front-end/src/app/(auth)/login/page.tsx
+++ b/front-end/src/app/(auth)/login/page.tsx
@@ -17,6 +17,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 
 import { api } from "@/lib/api";
+import axios from "axios";
 
 const formSchema = z.object({
   email: z.string().email({ message: "Please enter a valid email address" }),
@@ -41,8 +42,20 @@ const Login = () => {
       console.log("Form submitted:", values);
 
       const res = await api.post("/auth/sign-in", values);
+      const { token } = res.data;
+      localStorage.setItem("token", token);
 
-      router.push("/createProfile"); //
+      try {
+        await api.get("/profile/me");
+        router.push("/dashboard");
+      } catch (err) {
+        if (axios.isAxiosError(err) && err.response?.status === 404) {
+          router.push("/createProfile");
+        } else {
+          console.error("Profile check failed:", err);
+          router.push("/createProfile");
+        }
+      }
     } catch (error) {
       console.error("Login failed:", error);
     }

--- a/server/controllers/profileController.ts
+++ b/server/controllers/profileController.ts
@@ -40,3 +40,26 @@ export const createProfile = async (req: Request, res: Response) => {
     res.status(500).json({ message: "Server error", error: err });
   }
 };
+
+export const getProfile = async (req: Request, res: Response) => {
+  try {
+    const userId = req.user?.userId;
+
+    if (!userId) {
+      res.status(401).json({ message: "Unauthorized" });
+      return;
+    }
+
+    const profile = await prisma.profile.findUnique({ where: { userId } });
+
+    if (!profile) {
+      res.status(404).json({ message: "Profile not found" });
+      return;
+    }
+
+    res.status(200).json({ profile });
+  } catch (err) {
+    console.error("❌ Error fetching profile:", err);
+    res.status(500).json({ message: "Server error", error: err });
+  }
+};

--- a/server/routes/profile.ts
+++ b/server/routes/profile.ts
@@ -1,5 +1,5 @@
 import express from "express";
-import { createProfile } from "../controllers/profileController";
+import { createProfile, getProfile } from "../controllers/profileController";
 import { tokenChecker } from "../middleware/tokenChecker";
 import { upload } from "../middleware/upload";
 
@@ -14,5 +14,7 @@ CreateRouter.post(
   ]),
   createProfile
 );
+
+CreateRouter.get("/me", tokenChecker, getProfile);
 
 export default CreateRouter;


### PR DESCRIPTION
## Summary
- add `getProfile` controller to fetch the current user's profile
- expose `/profile/me` route in the API
- update login flow to save the token and check for an existing profile

## Testing
- `npm test` in `server` *(fails: no test specified)*
- `npm test` in `front-end` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864d85981388333bda5f5b6bfc64e2c