### PR TITLE
Fix bank card handling

### DIFF
--- a/front-end/src/app/createProfile/_components/payment.tsx
+++ b/front-end/src/app/createProfile/_components/payment.tsx
@@ -66,7 +66,7 @@ export default function PaymentForm() {
       return;
     }
 
-    const { expiryMonth, expiryYear, ...rest } = values;
+    const { expiryMonth, expiryYear, cvc, ...rest } = values;
 
     const expiryDate = new Date(Number(expiryYear), Number(expiryMonth) - 1, 1);
 

--- a/server/controllers/bankCardController.ts
+++ b/server/controllers/bankCardController.ts
@@ -24,8 +24,11 @@ export const addBankCard = async (req: Request, res: Response) => {
       expiryDate: string;
     } = req.body;
 
-    const bankCard = await prisma.bankCard.create({
-      data: {
+    const existingCard = await prisma.bankCard.findUnique({ where: { userId } });
+
+    const bankCard = await prisma.bankCard.upsert({
+      where: { userId },
+      create: {
         country,
         firstName,
         lastName,
@@ -33,9 +36,19 @@ export const addBankCard = async (req: Request, res: Response) => {
         expiryDate: new Date(expiryDate),
         userId,
       },
+      update: {
+        country,
+        firstName,
+        lastName,
+        cardNumber,
+        expiryDate: new Date(expiryDate),
+      },
     });
 
-    res.status(201).json({ message: "Bank card added", bankCard });
+    res.status(existingCard ? 200 : 201).json({
+      message: existingCard ? "Bank card updated" : "Bank card added",
+      bankCard,
+    });
   } catch (err) {
     console.error("❌ Error saving card:", err);
     res.status(500).json({ message: "Server error", error: err });


### PR DESCRIPTION
## Summary
- ensure backend updates bank card if one already exists
- avoid sending CVC to backend when saving bank card

## Testing
- `npx tsc --noEmit` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_6864e8b67a1c8333ba405730b285b949