### PR TITLE
Implement dashboard API and header

### DIFF
--- a/front-end/src/app/dashboard/_components/header_2.tsx
+++ b/front-end/src/app/dashboard/_components/header_2.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -8,8 +11,23 @@ import {
 import Image from "next/image";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { ChevronDown } from "lucide-react";
+import { api } from "@/lib/api";
+
+type Profile = {
+  name: string;
+  avatarImage: string;
+};
 
 export const HeaderComponent = () => {
+  const [profile, setProfile] = useState<Profile | null>(null);
+
+  useEffect(() => {
+    api
+      .get("/profile/me")
+      .then((res) => setProfile(res.data.profile as Profile))
+      .catch(() => setProfile(null));
+  }, []);
+
   return (
     <header className="flex justify-between  pl-5 pr-15 pt-6">
       <div className="flex items-center gap-2.5">
@@ -20,10 +38,14 @@ export const HeaderComponent = () => {
         <DropdownMenu>
           <DropdownMenuTrigger className="flex items-center gap-2 outline-none">
             <Avatar className="w-10 h-10">
-              <AvatarImage src="/flow.png" alt="User avatar" />
-              <AvatarFallback>J</AvatarFallback>
+              <AvatarImage src={profile?.avatarImage ?? "/flow.png"} alt="User avatar" />
+              <AvatarFallback>
+                {profile?.name ? profile.name[0] : "U"}
+              </AvatarFallback>
             </Avatar>
-            <span className="text-lg font-semibold">Jake</span>
+            <span className="text-lg font-semibold">
+              {profile?.name ?? "User"}
+            </span>
             <ChevronDown className="w-4 h-4" />
           </DropdownMenuTrigger>
 

--- a/front-end/src/app/dashboard/home/page.tsx
+++ b/front-end/src/app/dashboard/home/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Image from "next/image";
 import { Loader2, Heart } from "lucide-react";
+import { api } from "@/lib/api";
 
 type DashboardData = {
   username: string;
@@ -22,12 +23,13 @@ export default function DashboardHome() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch("/api/dashboard")
-      .then((res) => res.json())
-      .then((json) => {
-        setData(json);
+    api
+      .get("/dashboard")
+      .then((res) => {
+        setData(res.data);
         setLoading(false);
-      });
+      })
+      .catch(() => setLoading(false));
   }, []);
 
   if (loading) {

--- a/server/controllers/dashboardController.ts
+++ b/server/controllers/dashboardController.ts
@@ -1,0 +1,49 @@
+import { Request, Response } from "express";
+import { prisma } from "../utils/prisma";
+
+export const getDashboard = async (req: Request, res: Response) => {
+  try {
+    const userId = req.user?.userId;
+
+    if (!userId) {
+      res.status(401).json({ message: "Unauthorized" });
+      return;
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      include: { profile: true, receivedDonations: true },
+    });
+
+    if (!user || !user.profile) {
+      res.status(404).json({ message: "User not found" });
+      return;
+    }
+
+    const earnings = user.receivedDonations.reduce(
+      (sum, d) => sum + d.amount,
+      0
+    );
+
+    const transactions = user.receivedDonations
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+      .slice(0, 10)
+      .map((d) => ({
+        id: d.id,
+        name: `Supporter ${d.donorId}`,
+        message: d.specialMessage,
+        amount: d.amount,
+        timeAgo: d.createdAt.toISOString(),
+      }));
+
+    res.status(200).json({
+      username: user.username,
+      avatar: user.profile.avatarImage,
+      earnings,
+      transactions,
+    });
+  } catch (err) {
+    console.error("\u274c Error fetching dashboard:", err);
+    res.status(500).json({ message: "Server error", error: err });
+  }
+};

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,6 +5,7 @@ import { PrismaClient } from "@prisma/client";
 import authRoutes from "./routes/auth";
 import CreateRouter from "./routes/profile";
 import bankCardRouter from "./routes/bankCard";
+import dashboardRouter from "./routes/dashboard";
 
 dotenv.config();
 
@@ -25,6 +26,7 @@ app.use(express.json());
 app.use("/api/auth", authRoutes);
 app.use("/api/profile", CreateRouter);
 app.use("/api/bank-card", bankCardRouter);
+app.use("/api/dashboard", dashboardRouter);
 
 // Start server
 const port = process.env.PORT || 8000;

--- a/server/routes/dashboard.ts
+++ b/server/routes/dashboard.ts
@@ -1,0 +1,9 @@
+import express from "express";
+import { getDashboard } from "../controllers/dashboardController";
+import { tokenChecker } from "../middleware/tokenChecker";
+
+const router = express.Router();
+
+router.get("/", tokenChecker, getDashboard);
+
+export default router;


### PR DESCRIPTION
## Summary
- make dashboard header fetch user info
- refactor home page to use axios
- create server endpoint for dashboard data
- register dashboard route in server

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` in `server` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_6864ecdbcadc83339eff93a07d1684ef