### PR TITLE
Fix token verification endpoint

### DIFF
--- a/front-end/src/app/_components/Userprovider.tsx
+++ b/front-end/src/app/_components/Userprovider.tsx
@@ -28,9 +28,12 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
 
   const tokenChecker = async (token: string) => {
     try {
-      const response = await axios.post("http://localhost:8000/verify/auth", {
-        token,
-      });
+      const response = await axios.post(
+        "http://localhost:8000/api/auth/verify",
+        {
+          token,
+        }
+      );
 
       const userId = response.data?.destructToken?.userId;
       if (userId) {


### PR DESCRIPTION
## Summary
- correct token verification URL in frontend `Userprovider`

## Testing
- `npm test` (fails: Missing script)
- `npm test --silent` in server (prints 'Error: no test specified')

------
https://chatgpt.com/codex/tasks/task_e_6867371cc04883339a285a7c2695cbf1